### PR TITLE
Logging for HID module

### DIFF
--- a/app_linux.md
+++ b/app_linux.md
@@ -1,0 +1,26 @@
+# Running On Linux
+
+These instructions can be used to run the software directly from the repo (useful for development) or from a downloaded release. Before following the instructions you should open a terminal and change directory either to the root of this repo or the directory where you have extracted the release you downloaded. The directory you are in should contain the `pc_software` folder.
+
+```bash
+cd pc_software
+python -m venv venv
+. venv/bin/activate
+pip install appdirs hidapi
+python duckypad_config.py
+```
+
+## Udev Rule
+
+If you want to use the functionality to manage your duckyPad profile via USB then you may need to install a Udev rule to allow your user to access the device. You can do that by creating the file `/etc/udev/rules.d/20-duckyPad.rules` with this content:
+
+```
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="d11c", TAG+="uaccess", TAG+="udev-acl"
+```
+
+The rule will be applied on the next reboot or you can force a reload of the rules by running:
+
+```bash
+sudo udevadm trigger
+sudo udevadm control --reload-rules
+```

--- a/app_linux.md
+++ b/app_linux.md
@@ -24,3 +24,11 @@ The rule will be applied on the next reboot or you can force a reload of the rul
 sudo udevadm trigger
 sudo udevadm control --reload-rules
 ```
+
+## Debugging
+
+To view all of the HID connection debug logging (warning this is very verbose) you can start the app with `HID_OP_LOG=debug` like this:
+
+```bash
+HID_OP_LOG=debug python duckypad_config.py
+```


### PR DESCRIPTION
I could see that you also debugged this in the past by adding print statements so I added logging how I would usually lay it out for a small app. It is very verbose when enabled but it was quite helpful for me to understand what is going on here. There should be no change for people running it without the `HID_OP_LOG=debug` environment variable set because I only added debug log messages.

This is based on https://github.com/dekuNukem/duckyPad/pull/61 so that one should be merged first.