### PR TITLE
Add a `sleep` command to the HID interface

### DIFF
--- a/firmware/code/Src/my_tasks.c
+++ b/firmware/code/Src/my_tasks.c
@@ -490,6 +490,7 @@ uint8_t hid_tx_buf[HID_TX_BUF_SIZE];
 #define HID_COMMAND_CREATE_DIR 18
 #define HID_COMMAND_DELETE_DIR 19
 #define HID_COMMAND_SW_RESET 20
+#define HID_COMMAND_SLEEP 21
 
 
 #define HID_RESPONSE_OK 0
@@ -940,6 +941,24 @@ void handle_hid_command(void)
   {
     USBD_CUSTOM_HID_SendReport(&hUsbDeviceFS, hid_tx_buf, HID_TX_BUF_SIZE);
     NVIC_SystemReset();
+  }
+  /*
+  HID SLEEP
+  -----------
+  PC to duckyPad:
+  [0]   report_id: always 5
+  [1]   seq number
+  [2]   command
+  -----------
+  duckyPad to PC
+  [0]   report_id: always 4
+  [1]   seq number (same as above)
+  [2]   0 = OK
+  */
+  else if(command_type == HID_COMMAND_SLEEP)
+  {
+    USBD_CUSTOM_HID_SendReport(&hUsbDeviceFS, hid_tx_buf, HID_TX_BUF_SIZE);
+    start_sleeping();
   }
   /*
     unknown command


### PR DESCRIPTION
Adds a sleep command to the HID interface.

- Reserves a new command (`21`).
- Adds a handler for this command. The handler immediately responds with an OK, and calls the sleep routine.

⚠️ This code is not tested. I do not have the tools or knowledge to compile and test this code. If any changes should be made, feel free to request/make changes, or close the PR if I'm really doing something funky. As far as I am aware, cases in which the device should not respond with OK are already handled.