### PR TITLE
Fix for python libraries on Linux Mint

### DIFF
--- a/app_posix.md
+++ b/app_posix.md
@@ -13,6 +13,16 @@ sudo DUCKYPAD_UI_SCALE=2 python3 duckypad_config.py
 # adjust the number for best results
 ```
 
+### Linux Mint Users
+
+If the above commands give you errors when attempting to execute `sudo python3 duckypad_config.py` perform the following first:
+
+```bash
+sudo apt install python3-tk
+sudo apt install python3-appdirs
+sudo apt install python3-hid
+```
+
 ## Udev Rule
 
 To enable USB profile editing on Linux, you may need to install a Udev rule to allow your user to access the HID device.


### PR DESCRIPTION
The instructions [here](Running duckyPad Configurator on Linux) do not appear to work for my Linux Mint PC.

I wanted to post how I was able to fix this. So that maybe we can update the documentation. I suspect this would affect Ubuntu as well since Linux Mint is based off of Ubuntu.

Let me know your thoughts. It seemed that whenever I tried to execute the python script (duckypad_config.py) I got the following:
```bash
sudo python3 duckypad_config.py
Traceback (most recent call last):
  File "duckypad_config.py", line 13, in <module>
    from tkinter import *
ModuleNotFoundError: No module named 'tkinter'
```

Once I installed tk, I would then get the error for **appdirs** then for **hid**

To fix this, I performed the following:

```bash
sudo apt install python3-tk
sudo apt install python3-appdirs
sudo apt install python3-hid
```