### PR TITLE
fix for Run this script!

### DIFF
--- a/app_posix.md
+++ b/app_posix.md
@@ -24,6 +24,12 @@ sudo apt install python3-hid
 pip3 install pyautogui
 ```
 
+Ubuntu/Pop!_OS/Linux Mint Users will also need to execute the duckypad_config.py file as non-sudo.
+
+```bash
+python3 duckypad_config.py
+```
+
 ## Udev Rule
 
 To enable USB profile editing on Linux, you may need to install a Udev rule to allow your user to access the HID device.

--- a/app_posix.md
+++ b/app_posix.md
@@ -21,6 +21,7 @@ If the above commands give you errors when attempting to execute `sudo python3 d
 sudo apt install python3-tk
 sudo apt install python3-appdirs
 sudo apt install python3-hid
+pip3 install pyautogui
 ```
 
 ## Udev Rule


### PR DESCRIPTION
The **Run this script!** option does not work on Ubuntu variants without installing the pyautogui library. This PR hopes to add to the documentation. I cannot confirm for other distros so I will add this to the **Ubuntu/Pop!_OS/Linux Mint Users** section