### PR TITLE
Linux install script added

### DIFF
--- a/app_posix.md
+++ b/app_posix.md
@@ -1,5 +1,17 @@
 # Running duckyPad Configurator on Linux
 
+## Script Install Method
+To use duckyPad configurator, clone the repo or download the latest source files from the [release page](https://github.com/dekuNukem/duckyPad/releases/latest). Enter `pc_software` directory in terminal, then use the duckypad_config_install.sh file to install the software on your system.
+
+The Install script will move all files to the `/opt/duckypad_config` directory. It will also install the python dependancies and the udev rules. Currently, this has only been tested with Ubuntu based distros.
+
+```bash
+sudo +x ./duckypad_config_install.sh
+./duckypad_config_install.sh
+```
+
+## Manual Install Method
+
 To use duckyPad configurator, clone the repo or download the latest source files from the [release page](https://github.com/dekuNukem/duckyPad/releases/latest). Enter `pc_software` directory in terminal, then use the following commands to install dependencies and launch the app:
 
 ```bash
@@ -23,7 +35,7 @@ sudo apt install python3-appdirs
 sudo apt install python3-hid
 ```
 
-## Udev Rule
+### Udev Rule
 
 To enable USB profile editing on Linux, you may need to install a Udev rule to allow your user to access the HID device.
 

--- a/pc_software/duckypad_config_install.sh
+++ b/pc_software/duckypad_config_install.sh
@@ -18,7 +18,8 @@ while true; do
 done
 
 ## create .desktop file
-tee /usr/share/applications/duckyconfig.desktop <<EOF
+echo "Installing .desktop file to /usr/share/applications/duckyconfig.desktop"
+tee /usr/share/applications/duckyconfig.desktop <<EOF &> /dev/null
 #!/usr/bin/env xdg-open
 [Desktop Entry]
 Name=DuckyPad Configurator
@@ -31,6 +32,7 @@ EOF
 
 # Determine Distro
 . /etc/os-release
+echo "Distro detected: " $NAME
 
 #Check if pip3 is installed
 command -v pip3 >/dev/null 2>&1 || { echo >&2 "pip3 cannot be detected on your system. Please install."; pip=false; }
@@ -50,20 +52,21 @@ if [ "$NAME" == 'Linux Mint' ] || [ "$NAME" == 'Pop!_OS' ] || [ "$NAME" == 'Ubun
     fi
 
     echo "Installing python3-tk.."
-    sudo apt-get -qq install python3-tk -y || echo "Unable to install python3-tk"
+    sudo apt-get -qq install python3-tk -y &> /dev/null || echo "Unable to install python3-tk"
     echo "Installing python3-appdirs.."
-    sudo apt-get -qq install python3-appdirs -y || echo "Unable to install python3-appdirs"
+    sudo apt-get -qq install python3-appdirs -y &> /dev/null || echo "Unable to install python3-appdirs"
     echo "Installing python3-hid.."
-    sudo apt-get -qq install python3-hid -y || echo "Unable to install python3-hid"
+    sudo apt-get -qq install python3-hid -y &> /dev/null || echo "Unable to install python3-hid"
     echo "Installing pyautogui"
-    pip3 install pyautogui || echo "Unable to install pyautogui"
+    pip3 install pyautogui &> /dev/null || echo "Unable to install pyautogui"
 
 else
 
-    pip3 install appdirs hidapi
+    pip3 install appdirs hidapi || echo "Unable to install appdirs or hidapi"
 
 fi
 
+#create directories in /opt for python files
 mkdir -p /opt/duckypad_config
 cp -R ./ /opt/duckypad_config/
 

--- a/pc_software/duckypad_config_install.sh
+++ b/pc_software/duckypad_config_install.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#Install Script for Ducky Config
+#
+
+# Check if running as root
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
+
+while true; do
+    read -p "Do you wish to install with Hi-DPI support? " yn
+    case $yn in
+        [Yy]* ) HIDPI="env DUCKYPAD_UI_SCALE=2"; break;;
+        [Nn]* ) HIDPI=""; break;;
+        * ) echo "Please answer yes or no.";;
+    esac
+done
+
+## create .desktop file
+tee /usr/share/applications/duckyconfig.desktop <<EOF
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Name=DuckyPad Configurator
+Version=v0.13.3
+Icon=/opt/duckypad_config/icon.ico
+Exec=$HIDPI python3 /opt/duckypad_config/duckypad_config.py
+Terminal=false
+Type=Application
+EOF
+
+# Determine Distro
+. /etc/os-release
+
+# Install Python libraries based on distro
+if [ "$NAME" == 'Linux Mint' ] || [ "$NAME" == 'Pop!_OS' ] || [ "$NAME" == 'Ubuntu' ]; then
+
+    echo "Installing python3-tk.."
+    sudo apt-get -qq install python3-tk -y || echo "Unable to install python3-tk"
+    echo "Installing python3-appdirs.."
+    sudo apt-get -qq install python3-appdirs -y || echo "Unable to install python3-appdirs"
+    echo "Installing python3-hid.."
+    sudo apt-get -qq install python3-hid -y || echo "Unable to install python3-hid"
+
+else
+
+    pip3 install appdirs hidapi
+
+fi
+
+mkdir -p /opt/duckypad_config
+cp -R ./ /opt/duckypad_config/
+
+# Setup udev rules
+echo "Setting up udev rules..."
+udev_rule="SUBSYSTEMS==\"usb\", ATTRS{idVendor}==\"0483\", ATTRS{idProduct}==\"d11c\", TAG+=\"uaccess\", TAG+=\"udev-acl\""
+echo $udev_rule > /etc/udev/rules.d/20-duckyPad.rules
+
+# Reload udev rules
+echo "Reloading udev rules (1/2)..."
+sudo udevadm trigger
+echo "Reloading udev rules (2/2)..."
+sudo udevadm control --reload-rules

--- a/pc_software/duckypad_config_install.sh
+++ b/pc_software/duckypad_config_install.sh
@@ -32,8 +32,22 @@ EOF
 # Determine Distro
 . /etc/os-release
 
+#Check if pip3 is installed
+command -v pip3 >/dev/null 2>&1 || { echo >&2 "pip3 cannot be detected on your system. Please install."; pip=false; }
+
 # Install Python libraries based on distro
 if [ "$NAME" == 'Linux Mint' ] || [ "$NAME" == 'Pop!_OS' ] || [ "$NAME" == 'Ubuntu' ]; then
+
+    if [ "$pip" = false ] ;then
+        while true; do
+            read -p "Do you wish to install pip3? " yn
+            case $yn in
+                [Yy]* ) sudo apt-get install python3-pip -y; break;;
+                [Nn]* ) break;;
+                * ) echo "Please answer yes or no.";;
+            esac
+        done
+    fi
 
     echo "Installing python3-tk.."
     sudo apt-get -qq install python3-tk -y || echo "Unable to install python3-tk"
@@ -41,6 +55,8 @@ if [ "$NAME" == 'Linux Mint' ] || [ "$NAME" == 'Pop!_OS' ] || [ "$NAME" == 'Ubun
     sudo apt-get -qq install python3-appdirs -y || echo "Unable to install python3-appdirs"
     echo "Installing python3-hid.."
     sudo apt-get -qq install python3-hid -y || echo "Unable to install python3-hid"
+    echo "Installing pyautogui"
+    pip3 install pyautogui || echo "Unable to install pyautogui"
 
 else
 


### PR DESCRIPTION
This PR includes an install script for Linux. It adds all required py files to the `/opt/duckypad_config` folder.

The script has only been tested with Ubuntu based distros.

The only portion that requires distro specific commands are the installation of python libraries. I have added an if statement that others can modify to add the commands needed to install the libraries on their distro.

The script also adds a .desktop file to `/usr/share/applications`