### PR TITLE
Add sudo to one command, as it need administrative rights

### DIFF
--- a/firmware_updates_and_version_history.md
+++ b/firmware_updates_and_version_history.md
@@ -76,7 +76,7 @@ Using terminal, install [dfu-util](http://dfu-util.sourceforge.net/) with a pack
 
 Hold DFU button and connect duckyPad, then run:
 
-`dfu-util --device ,0483:df11 -a 0 -D /path/to/duckypad_firmware.dfu`
+`sudo dfu-util --device ,0483:df11 -a 0 -D /path/to/duckypad_firmware.dfu`
 
 After completion, press **`RESET`** button (or power-cycle) to start using the new firmware. 
 


### PR DESCRIPTION
![Capture d’écran du 2022-09-26 16-26-45](https://user-images.githubusercontent.com/13170204/192302640-68c2576b-6bad-4374-8dcc-3a2415911266.png)
As described in the libusb documentation : https://libusb.sourceforge.io/api-1.0/group__libusb__misc.html#gab2323aa0f04bc22038e7e1740b2f29ef

LIBUSB_ERROR_ACCESS | Access denied (insufficient permissions)
-- | --

[While we could give the user access to USB devices](https://askubuntu.com/questions/978552/how-do-i-make-libusb-work-as-non-root), It's far more straightforward to just flash the pad with administrative rights.

I could also reword the text before the command to indicate to execute it with administrative rights, but that's more of a Windows user way of handling it.
