### PR TITLE
Add shell.nix and update readme for NixOS 

### DIFF
--- a/app_posix.md
+++ b/app_posix.md
@@ -51,6 +51,14 @@ Ubuntu/Pop!_OS/Linux Mint Users will also need to execute the duckypad_config.py
 python3 duckypad_config.py
 ```
 
+### NixOS - nix-shell
+
+To run duckypad on NixOS download the [shell.nix](https://github.com/dekuNukem/duckyPad/tree/master/resources/shell.nix) file.
+
+```bash
+nix-shell
+```
+
 ### Udev Rule
 
 To enable USB profile editing on Linux, you may need to install a Udev rule to allow your user to access the HID device.

--- a/resources/shell.nix
+++ b/resources/shell.nix
@@ -1,0 +1,22 @@
+{nixpkgs ? import <nixpkgs> {}}:
+
+nixpkgs.mkShell {
+
+  nativeBuildInputs = with nixpkgs; [ pkgs.python311Full pkgs.python3Packages.pyautogui pkgs.python3Packages.appdirs pkgs.python3Packages.hidapi pkgs.unzip];
+  shellHook = ''
+  if [[ ! -d duckypad ]]; then
+    mkdir -p duckypad
+    if [ -f duckypad_config_1.6.3_source.zip ]; then
+        mv duckypad_config_1.6.3_source.zip duckypad/
+    else
+        wget https://github.com/dekuNukem/duckyPad/releases/download/1.6.3/duckypad_config_1.6.3_source.zip
+        mv duckypad_config_1.6.3_source.zip duckypad/
+    fi
+  cd duckypad
+    unzip duckypad_config_1.6.3_source.zip
+    mv duckypad_config_1.6.3_source.zip ../
+    cd ../
+  fi
+  python3 duckypad/duckypad_config.py
+  '';
+}


### PR DESCRIPTION
Enables duckypad to run on NixOS using nix-shell. 
Updated app_posix.md and created shell.nix file in resources.