### PR TITLE
Implement HID_COMMAND_SET_LED_SINGLE (command 4) for host per-key LED control

### DIFF
--- a/firmware/evo/Src/hid_task.c
+++ b/firmware/evo/Src/hid_task.c
@@ -601,6 +601,37 @@ void parse_hid_msg(uint8_t* this_msg)
       hid_tx_buf[2] = HID_RESPONSE_GENERIC_ERROR;
     send_hid_cmd_response(hid_tx_buf);
   }
+  /*
+    SET LED SINGLE
+    -----------
+    PC to duckyPad:
+    [0]   Usage ID, always 5
+    [1]   Unused
+    [2]   Command
+    [3]   LED index (0 to NEOPIXEL_COUNT-1)
+    [4]   Red
+    [5]   Green
+    [6]   Blue
+    -----------
+    duckyPad to PC
+    [0]   Usage ID, always 4
+    [1]   Unused
+    [2]   Status, 0 = OK
+  */
+  else if(command_type == HID_COMMAND_SET_LED_SINGLE)
+  {
+    uint8_t led_index = this_msg[3];
+    if(led_index >= NEOPIXEL_COUNT)
+    {
+      hid_tx_buf[2] = HID_RESPONSE_INVALID_ARG;
+    }
+    else
+    {
+      set_pixel_3color_update_buffer(led_index, this_msg[4], this_msg[5], this_msg[6]);
+      neopixel_draw_current_buffer();
+    }
+    send_hid_cmd_response(hid_tx_buf);
+  }
   else // not a valid HID command
   {
     hid_tx_buf[2] = HID_RESPONSE_UNKNOWN_CMD;


### PR DESCRIPTION
`HID_COMMAND_SET_LED_SINGLE` (command 4) is defined in `firmware/evo/Inc/hid_task.h` and documented in the autoswitcher's `HID_details.md`, but `parse_hid_msg()` in `firmware/evo/Src/hid_task.c` has no branch for it — so it returns
  `HID_RESPONSE_UNKNOWN_CMD` (status 6) and host software can't set a key's colour.

This wires it to the existing neopixel primitives (`set_pixel_3color_update_buffer` + `neopixel_draw_current_buffer`) with an `INVALID_ARG` guard, matching the
  documented byte layout ([3]=index, [4..6]=RGB) and the file's style.

Built with arm-none-eabi and flashed to a real OG duckyPad (STM32F072C8): returns status 0 and lights the addressed key (stock returned 6). Minimal: 1 file, +31 lines.